### PR TITLE
prefix 0x for rpc compat

### DIFF
--- a/sdk-adapter/source/index.ts
+++ b/sdk-adapter/source/index.ts
@@ -210,7 +210,7 @@ function stringToByteArray(hex: string): Uint8Array {
 }
 
 function bigintToHexAddress(value: bigint): string {
-	return value.toString(16).padStart(40, '0')
+	return `0x${value.toString(16).padStart(40, '0')}`
 }
 
 function bigintToHexQuantity(value: bigint): string {


### PR DESCRIPTION
Verified the only place this is used is to generate these storage and proof payloads within an array

Fixes #13 