### PR TITLE
Fixes bug in bigint from hex conversion and getBlockByNumber.

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-contracts",
 	"description": "Contracts for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk-adapter/package-lock.json
+++ b/sdk-adapter/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk-adapter/package.json
+++ b/sdk-adapter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
 	"description": "Adapter for using @keydonix/uniswap-oracle-sdk with legacy providers like raw JSON-RPC, ethers, web3.js, etc.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk-adapter/source/index.ts
+++ b/sdk-adapter/source/index.ts
@@ -8,7 +8,7 @@ type Provider = SendAsyncProvider | RequestProvider
 export function getBlockByNumberFactory(provider: Provider): OracleSdk.EthGetBlockByNumber {
 	const requestProvider = normalizeProvider(provider)
 	return async (blockNumber: bigint | 'latest') => {
-		const block = await requestProvider.request('eth_getBlockByNumber', [`0x${blockNumber.toString(16)}`])
+		const block = await requestProvider.request('eth_getBlockByNumber', [`0x${blockNumber.toString(16)}`, false])
 		assertPlainObject(block)
 		assertProperty(block, 'parentHash', 'string')
 		assertProperty(block, 'sha3Uncles', 'string')
@@ -194,7 +194,7 @@ function stringToBigint(hex: string): bigint {
 	const match = /^(?:0x)?([a-fA-F0-9]*)$/.exec(hex)
 	if (match === null) throw new Error(`Expected a hex string encoded number with an optional '0x' prefix but received ${hex}`)
 	const normalized = match[1]
-	return BigInt(normalized)
+	return BigInt(`0x${normalized}`)
 }
 
 function stringToByteArray(hex: string): Uint8Array {

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
 	"description": "TypeScript/JavaScript SDK for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fixes #17
Fixes #18

As you may have guessed at this point @cloudonshore, we haven't tested/used the adapter much... all my stuff uses a different set of libraries and I wrote the adapter to make it easier to use for people using traditional web3 providers.  Thanks for reporting all of these bugs in the adapter!