### PR TITLE
Adds support for `ethers` JsonRpcProvider.

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-contracts",
 	"description": "Contracts for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk-adapter/package-lock.json
+++ b/sdk-adapter/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk-adapter/package.json
+++ b/sdk-adapter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
 	"description": "Adapter for using @keydonix/uniswap-oracle-sdk with legacy providers like raw JSON-RPC, ethers, web3.js, etc.",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
 	"description": "TypeScript/JavaScript SDK for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This mechanism for detecting an ethers JsonRpcProvider is a bit sketchy, but ethers is a popular enough library that it is worth it for now.  The next version of ethers should have a bridge that may work which would be the cleanere way to handle this, though TBD if it will uspport `eth_getProof`.

Also fixes a bug in `getblockByNumberFactory` where if you pass in `latest` it would try to fetch `0xlatest`.