### PR TITLE
Reodrers detection of provider type.

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-contracts",
 	"description": "Contracts for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk-adapter/package-lock.json
+++ b/sdk-adapter/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk-adapter/package.json
+++ b/sdk-adapter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk-adapter",
 	"description": "Adapter for using @keydonix/uniswap-oracle-sdk with legacy providers like raw JSON-RPC, ethers, web3.js, etc.",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@keydonix/uniswap-oracle-sdk",
 	"description": "TypeScript/JavaScript SDK for a Uniswap price oracle that uses merkle proofs for calculating volume weight moving average price.",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
'request' is the modern standard.  'sendAsync' is the legacy standard and 'send' is non-standard, so `send` should be the last attempt, not the middle attempt.

Also improved error messaging when a user provides not-a-provider.