### PR TITLE
Fixes casing consistency on `keydonix` namespace.

### DIFF
--- a/demo/contracts/TestWrappers.sol
+++ b/demo/contracts/TestWrappers.sol
@@ -1,9 +1,9 @@
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 
-import { BlockVerifier } from "@Keydonix/BlockVerifier.sol";
-import { MerklePatriciaVerifier } from "@Keydonix/MerklePatriciaVerifier.sol";
-import { Rlp } from "@Keydonix/Rlp.sol";
+import { BlockVerifier } from "@keydonix/BlockVerifier.sol";
+import { MerklePatriciaVerifier } from "@keydonix/MerklePatriciaVerifier.sol";
+import { Rlp } from "@keydonix/Rlp.sol";
 
 contract BlockVerifierWrapper {
 	function extractStateRootAndTimestamp(bytes memory input) public view returns (bytes32 stateRoot, uint256 blockTimestamp, uint256 blockNumber) {

--- a/demo/scripts/compile-contracts.ts
+++ b/demo/scripts/compile-contracts.ts
@@ -6,12 +6,12 @@ import { uniswapCompilerOutput } from './uniswap-compiler-output'
 
 const outputFileNamePrefix = 'price-emitter'
 const sourceFiles = [
-	{ key: '@Keydonix/UniswapOracle.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/UniswapOracle.sol' },
-	{ key: '@Keydonix/IUniswapV2Pair.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/IUniswapV2Pair.sol' },
-	{ key: '@Keydonix/BlockVerifier.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/BlockVerifier.sol' },
-	{ key: '@Keydonix/MerklePatriciaVerifier.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/MerklePatriciaVerifier.sol' },
-	{ key: '@Keydonix/Rlp.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/Rlp.sol' },
-	{ key: '@Keydonix/UQ112x112.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/UQ112x112.sol' },
+	{ key: '@keydonix/UniswapOracle.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/UniswapOracle.sol' },
+	{ key: '@keydonix/IUniswapV2Pair.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/IUniswapV2Pair.sol' },
+	{ key: '@keydonix/BlockVerifier.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/BlockVerifier.sol' },
+	{ key: '@keydonix/MerklePatriciaVerifier.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/MerklePatriciaVerifier.sol' },
+	{ key: '@keydonix/Rlp.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/Rlp.sol' },
+	{ key: '@keydonix/UQ112x112.sol', path: 'node_modules/@keydonix/uniswap-oracle-contracts/source/UQ112x112.sol' },
 	{ key: 'PriceEmitter.sol', path: 'contracts/PriceEmitter.sol' },
 	{ key: 'TestWrappers.sol', path: 'contracts/TestWrappers.sol' },
 	{ key: 'TestErc20.sol', path: 'contracts/TestErc20.sol' },


### PR DESCRIPTION
Fixes #36 

#34 changed some paths to lowercase because NPM namespaces are always lowercase, but it didn't change everything.  This brings consistency to use lowercase everywhere.